### PR TITLE
Update Configuration.h

### DIFF
--- a/source/Marlin/Configuration.h
+++ b/source/Marlin/Configuration.h
@@ -1018,7 +1018,7 @@
  *     |    [-]    |
  *     O-- FRONT --+
  */
-#define NOZZLE_TO_PROBE_OFFSET { 37.5,0, 0 }
+#define NOZZLE_TO_PROBE_OFFSET { 37.5,4, 0 }
 
 // Most probes should stay away from the edges of the bed, but
 // with NOZZLE_AS_PROBE this can be negative for a wider probing area.


### PR DESCRIPTION
Changed probe's y-offset coordinates from 0 to +4 as this reflects the actual position much more precise than 0.  
I'll probably re-measure and verify the +4mm in the somewhat future again as this is the result from a quick measurement being taken in the past, but I personally use this setting in my Klipper fw ever since and it seems to be correct.   
So I'd suggest to change it to +4 accordingly here as well (either by taking this PR or just setting it by your own) for now.  

Greetings! ;)